### PR TITLE
Added Documentation and Cleaned up Macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "totems"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["ObliqueMotion <aeketn@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -11,15 +11,39 @@ let result = "5".parse::<u32>();
 assert_ok!(&result);
 ```
 
-### `assert_ok!().with_value()`
+### `assert_ok!() with inequalities`
 
 ```rust
 use totems::assert_ok;
 let result = "5".parse::<u32>();
-assert_ok!(&result).with_value(&5);
+assert_ok!(&result, value == &5);
+assert_ok!(&result, value != &0);
+assert_ok!(&result, value <  &6);
+assert_ok!(&result, value <= &6);
+assert_ok!(&result, value >  &4);
+assert_ok!(&result, value >= &4);
 ```
 
 ### `assert_err!()`
+
+```rust
+use totems::assert_err;
+let result = "z".parse::<u32>();
+assert_err!(&result);
+```
+
+### `assert_err!() with inequalities`
+
+```rust
+use totems::assert_err;
+let result: Result<(), u32> = Err(5);
+assert_err!(&result, value == &5);
+assert_err!(&result, value != &0);
+assert_err!(&result, value <  &6);
+assert_err!(&result, value <= &5);
+assert_err!(&result, value >  &4);
+assert_err!(&result, value >= &5);
+```
 
 ```rust
 use totems::assert_err;
@@ -35,12 +59,17 @@ let option = "5".parse::<u32>().ok();
 assert_some!(&option);
 ```
 
-### `assert_some!().with_value()`
+### `assert_some!() with inequalities`
 
 ```rust
 use totems::assert_some;
 let option = "5".parse::<u32>().ok();
-assert_some!(&option).with_value(&5);
+assert_some!(&option, value == &5);
+assert_some!(&option, value != &0);
+assert_some!(&option, value <  &6);
+assert_some!(&option, value <= &6);
+assert_some!(&option, value >  &4);
+assert_some!(&option, value >= &4);
 ```
 
 ### `assert_none!()`

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -2,6 +2,35 @@
 // Macros
 //=============================================================================================
 
+/// Asserts that an `item` is contained within a `collection`.
+/// 
+/// ### Parameters
+/// 
+/// - `&collection` A reference to a collection.
+/// - `&item` A reference to an item to compare to items in the collection.
+/// 
+/// ### Dependencies
+/// - `collection` must implement [Iterator](https://doc.rust-lang.org/std/iter/trait.Iterator.html).
+/// - `&collection` must implement [IntoIterator](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html).
+/// - `item` must implement PartialEq for the types in `collection`.
+/// 
+/// ### Example
+///
+/// ```
+/// use totems::assert_contains;
+/// let vec = vec![1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+/// let x = 5;
+/// assert_contains!(&vec, &x);
+/// ```
+///
+/// ### Example Error Messages 
+///
+/// ```text 
+/// thread 'main' panicked at 'assertion failed: (collection contains item)
+///        item: 2
+///  collection: [1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
+/// ', src/collections.rs:149:9
+/// ```
 #[macro_export]
 macro_rules! assert_contains {
     ($collection:expr, $item:expr) => {
@@ -14,18 +43,46 @@ macro_rules! assert_contains {
     };
 }
 
+/// Asserts that *all* `items` in a `collection` match a `predicate`.
+/// 
+/// ### Parameters
+/// 
+/// - `&collection` A reference to a collection.
+/// - `predicate` A closure or function that takes an `item` and returns a boolean.
+/// - `description` ***(optional)*** A string describing the predicate.
+/// 
+/// ### Dependencies
+/// - `collection` must implement [Iterator](https://doc.rust-lang.org/std/iter/trait.Iterator.html).
+/// - `&collection` must implement [IntoIterator](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html).
+/// 
+/// ### Example
+///
+/// ```
+/// use totems::assert_all;
+/// let vec = vec![1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+/// assert_all!(&vec, |&x| x > 0, "all > 0");
+/// ```
+///
+/// ### Example Error Messages 
+///
+/// ```text 
+/// thread 'main' panicked at 'assertion failed: (all elements of collection match predicate)
+///   predicate: all < 0
+///  collection: [-1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
+/// ', src/collections.rs:165:9
+/// ```
 #[macro_export]
 macro_rules! assert_all {
     ($collection:expr, $predicate:expr) => {
         if false == $collection.into_iter().all($predicate) {
-            panic!("assertion failed: (all elements of collection match predicate) collection: {:?}",
+            panic!("assertion failed: (all elements of collection match predicate) collection: {:?}\n",
                 $collection,
             )
         }
     };
     ($collection:expr, $predicate:expr, $($arg:tt)+) => {
         if false == $collection.into_iter().all($predicate) {
-            panic!("assertion failed: (all elements of collection match predicate)\n  predicate: {}\n collection: {:?}",
+            panic!("assertion failed: (all elements of collection match predicate)\n  predicate: {}\n collection: {:?}\n",
                 format_args!($($arg)+),
                 $collection,
             )
@@ -33,18 +90,46 @@ macro_rules! assert_all {
     }
 }
 
+/// Asserts that *any* `item` in a `collection` matches a `predicate`.
+/// 
+/// ### Parameters
+/// 
+/// - `&collection` A reference to a collection.
+/// - `predicate` A closure or function that takes an `item` and returns a boolean.
+/// - `description` ***(optional)*** A string describing the predicate.
+/// 
+/// ### Dependencies
+/// - `collection` must implement [Iterator](https://doc.rust-lang.org/std/iter/trait.Iterator.html).
+/// - `&collection` must implement [IntoIterator](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html).
+/// 
+/// ### Example
+///
+/// ```
+/// use totems::assert_any;
+/// let vec = vec![1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+/// assert_any!(&vec, |&x| x > 0, "any > 0");
+/// ```
+///
+/// ### Example Error Messages 
+///
+/// ```text 
+/// thread 'main' panicked at 'assertion failed: (any element of collection matches predicate)
+///   predicate: any < 0
+///  collection: [1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
+/// ', src/collections.rs:188:9
+/// ```
 #[macro_export]
 macro_rules! assert_any {
     ($collection:expr, $predicate:expr) => {
         if false == $collection.into_iter().any($predicate) {
-            panic!("assertion failed: (any element of collection matches predicate) collection: {:?}",
+            panic!("assertion failed: (any element of collection matches predicate) collection: {:?}\n",
                 $collection,
             )
         }
     };
     ($collection:expr, $predicate:expr, $($arg:tt)+) => {
         if false == $collection.into_iter().any($predicate) {
-            panic!("assertion failed: (any element of collection matches predicate)\n  predicate: {}\n collection: {:?}",
+            panic!("assertion failed: (any element of collection matches predicate)\n  predicate: {}\n collection: {:?}\n",
                 format_args!($($arg)+),
                 $collection,
             )
@@ -102,13 +187,13 @@ mod any {
     #[test]
     fn one_item_matches() {
         let vec = vec![-1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
-        assert_any!(&vec, |&x| x < 0, "all < 0");
+        assert_any!(&vec, |&x| x < 0, "any < 0");
     }
 
     #[test]
     #[should_panic]
     fn no_items_match() {
         let vec = vec![1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
-        assert_any!(&vec, |&x| x < 0, "x < 0");
+        assert_any!(&vec, |&x| x < 0, "any < 0");
     }
 }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,114 +1,427 @@
-use core::fmt::Debug;
-
-//=============================================================================================
-// Structs
-//=============================================================================================
-
-pub struct ChainOk<T>(T);
-pub struct ChainSome<T>(T);
-
-//=============================================================================================
-// Implementations
-//=============================================================================================
-
-impl<'a, T, E> ChainOk<&'a Result<T, E>>
-where
-    T: Debug + PartialEq
-{
-    pub fn new(result: &'a Result<T, E>) -> Self {
-        Self(result)
-    }
-
-    pub fn with_value(&self, right: &'a T) {
-        if let ChainOk(Ok(left)) = self {
-            if left != right {
-                panic!(
-                    "assertion failed: (Ok(left) => left == right)\n  left: {:?}\n right: {:?}\n",
-                    *left, right
-                );
-            }
-        }
-    }
-}
-
-impl<'a, T> ChainSome<&'a Option<T>>
-where
-    T: Debug + PartialEq
-{
-    pub fn new(option: &'a Option<T>) -> Self {
-        Self(option)
-    }
-
-    pub fn with_value(&self, right: &'a T) {
-        if let ChainSome(Some(left)) = self {
-            if left != right {
-                panic!(
-                    "assertion failed: (Some(left) => left == right)\n  left: {:?}\n right: {:?}\n",
-                    left, right
-                );
-            }
-        }
-    }
-}
-
 //=============================================================================================
 // Macros
 //=============================================================================================
 
+/// Asserts that a [Result](https://doc.rust-lang.org/std/result/enum.Result.html) is `Ok`
+/// 
+/// ### Parameters
+/// 
+/// - `&result` A reference to a result.
+/// - `&value` ***(optional)*** A reference to an item to compare to `Ok`'s inner value.
+/// 
+/// ### Dependencies
+/// 
+/// - `value` must be comparable to `Ok`'s inner value.
+/// 
+/// ### Examples
+///
+/// **Check for `Ok` only:**
+/// ```rust
+/// use totems::assert_ok;
+/// let result = "5".parse::<u32>();
+/// assert_ok!(&result)
+/// ```
+/// **Check for `Ok` and correct inner value:**
+/// ```rust
+/// use totems::assert_ok;
+/// let result = "5".parse::<u32>();
+/// assert_ok!(&result, value == &5);
+/// assert_ok!(&result, value != &0);
+/// assert_ok!(&result, value <  &6);
+/// assert_ok!(&result, value <= &6);
+/// assert_ok!(&result, value >  &4);
+/// assert_ok!(&result, value >= &4);
+/// ```
+/// 
+/// ### Example Error Messages
+/// 
+/// ```text
+/// thread 'main' panicked at 'assertion failed: (&result is Ok(_))
+///  &result: Err(ParseIntError { kind: InvalidDigit })
+/// ', src/enums.rs:498:9
+/// ```
+/// ```text
+/// thread 'main' panicked at 'assertion failed: (Ok(left) => { left <= right })
+///   left: 5
+///  right: 4
+/// ', src/enums.rs:465:9
+/// ```
 #[macro_export]
 macro_rules! assert_ok {
     ($result:expr) => {{
         if let Err(_) = $result {
             panic!(
-                "assertion failed: ({0} == Ok(_))\n {0}: {1:?}\n",
+                "assertion failed: ({0} is Ok(_))\n {0}: {1:?}\n",
                 stringify!($result),
                 $result,
             );
         }
-        $crate::enums::ChainOk::new($result)
+    }};
+    ($result:expr, value == $value:expr) => {{
+        assert_ok!($result);
+        if let Ok(val) = $result {
+            if val != $value {
+                panic!(
+                    "assertion failed: (Ok(left) => {{ left == right }})\n  left: {:?}\n right: {:?}\n",
+                    val,
+                    $value,
+                )
+            }
+        }
+    }};
+    ($result:expr, value != $value:expr) => {{
+        assert_ok!($result);
+        if let Ok(val) = $result {
+            if val == $value {
+                panic!(
+                    "assertion failed: (Ok(left) => {{ left != right }})\n  left: {:?}\n right: {:?}\n",
+                    val,
+                    $value,
+                )
+            }
+        }
+    }};
+    ($result:expr, value < $value:expr) => {{
+        assert_ok!($result);
+        if let Ok(val) = $result {
+            if val >= $value {
+                panic!(
+                    "assertion failed: (Ok(left) => {{ left < right }})\n  left: {:?}\n right: {:?}\n",
+                    val,
+                    $value,
+                )
+            }
+        }
+    }};
+    ($result:expr, value <= $value:expr) => {{
+        assert_ok!($result);
+        if let Ok(val) = $result {
+            if val > $value {
+                panic!(
+                    "assertion failed: (Ok(left) => {{ left <= right }})\n  left: {:?}\n right: {:?}\n",
+                    val,
+                    $value,
+                )
+            }
+        }
+    }};
+    ($result:expr, value > $value:expr) => {{
+        assert_ok!($result);
+        if let Ok(val) = $result {
+            if val <= $value {
+                panic!(
+                    "assertion failed: (Ok(left) => {{ left > right }})\n  left: {:?}\n right: {:?}\n",
+                    val,
+                    $value,
+                )
+            }
+        }
+    }};
+    ($result:expr, value >= $value:expr) => {{
+        assert_ok!($result);
+        if let Ok(val) = $result {
+            if val < $value {
+                panic!(
+                    "assertion failed: (Ok(left) => {{ left >= right }})\n  left: {:?}\n right: {:?}\n",
+                    val,
+                    $value,
+                )
+            }
+        }
     }};
 }
 
+/// Asserts that a [Result](https://doc.rust-lang.org/std/result/enum.Result.html) is `Err`
+/// 
+/// ### Parameters
+/// 
+/// - `&result` A reference to a result.
+/// - `&value` ***(optional)*** A reference to an item to compare to `Err`'s inner value.
+/// 
+/// ### Dependencies
+/// 
+/// - `value` must be comparable to `Err`'s inner type.
+/// 
+/// ### Examples
+///
+/// **Check for `Err` only:**
+/// ```rust
+/// use totems::assert_err;
+/// let result = "z".parse::<u32>();
+/// assert_err!(&result);
+/// ```
+/// **Check for `Err` and correct inner value:**
+/// ```rust
+/// use totems::assert_err;
+/// let result: Result<(), u32> = Err(5);
+/// assert_err!(&result, value == &5);
+/// assert_err!(&result, value != &0);
+/// assert_err!(&result, value <  &6);
+/// assert_err!(&result, value <= &5);
+/// assert_err!(&result, value >  &4);
+/// assert_err!(&result, value >= &5);
+/// ```
+/// 
+/// ### Example Error Messages
+/// 
+/// ```text
+/// thread 'enums::err::is_err' panicked at 'assertion failed: (result is Err(_))
+///  result: Ok(5)
+/// ', src/enums.rs:574:9
+/// ```
+/// ```text
+/// thread 'enums::err::eq_incorrect' panicked at 'assertion failed: (Err(left) => { left == right })
+///   left: "This message matches."
+///  right: "This message doesn\'t match."
+/// ', src/enums.rs:491:9
+/// ```
 #[macro_export]
 macro_rules! assert_err {
     ($result:expr) => {{
         if let Ok(_) = $result {
             panic!(
-                "assertion failed: ({0} == Err(_))\n {0}: {1:?}\n",
+                "assertion failed: ({0} is Err(_))\n {0}: {1:?}\n",
                 stringify!($result),
                 $result,
             );
         }
     }};
+    ($result:expr, value == $value:expr) => {{
+        assert_err!($result);
+        if let Err(val) = $result {
+            if val != $value {
+                panic!(
+                    "assertion failed: (Err(left) => {{ left == right }})\n  left: {:?}\n right: {:?}\n",
+                    val,
+                    $value,
+                )
+            }
+        }
+    }};
+    ($result:expr, value != $value:expr) => {{
+        assert_err!($result);
+        if let Err(val) = $result {
+            if val == $value {
+                panic!(
+                    "assertion failed: (Err(left) => {{ left != right }})\n  left: {:?}\n right: {:?}\n",
+                    val,
+                    $value,
+                )
+            }
+        }
+    }};
+    ($result:expr, value < $value:expr) => {{
+        assert_err!($result);
+        if let Err(val) = $result {
+            if val >= $value {
+                panic!(
+                    "assertion failed: (Err(left) => {{ left < right }})\n  left: {:?}\n right: {:?}\n",
+                    val,
+                    $value,
+                )
+            }
+        }
+    }};
+    ($result:expr, value <= $value:expr) => {{
+        assert_err!($result);
+        if let Err(val) = $result {
+            if val > $value {
+                panic!(
+                    "assertion failed: (Err(left) => {{ left <= right }})\n  left: {:?}\n right: {:?}\n",
+                    val,
+                    $value,
+                )
+            }
+        }
+    }};
+    ($result:expr, value > $value:expr) => {{
+        assert_err!($result);
+        if let Err(val) = $result {
+            if val <= $value {
+                panic!(
+                    "assertion failed: (Err(left) => {{ left > right }})\n  left: {:?}\n right: {:?}\n",
+                    val,
+                    $value,
+                )
+            }
+        }
+    }};
+    ($result:expr, value >= $value:expr) => {{
+        assert_err!($result);
+        if let Err(val) = $result {
+            if val < $value {
+                panic!(
+                    "assertion failed: (Err(left) => {{ left >= right }})\n  left: {:?}\n right: {:?}\n",
+                    val,
+                    $value,
+                )
+            }
+        }
+    }};
 }
 
+/// Asserts that an [Option](https://doc.rust-lang.org/std/option/enum.Option.html) is `Some`
+/// 
+/// ### Parameters
+/// 
+/// - `&option` A reference to an `Option`.
+/// - `&value` ***(optional)*** A reference to an item to compare to `Some`'s inner value.
+/// 
+/// ### Dependencies
+/// 
+/// - `value` must be comparable to `Ok`'s inner value.
+/// 
+/// ### Examples
+///
+/// **Check for `Some` only:**
+/// ```rust
+/// use totems::assert_some;
+/// let option = "5".parse::<u32>().ok();
+/// assert_some!(&option);
+/// ```
+/// **Check for `Some` and correct inner value:**
+/// ```rust
+/// use totems::assert_some;
+/// let option = "5".parse::<u32>().ok();
+/// assert_some!(&option, value == &5);
+/// assert_some!(&option, value != &0);
+/// assert_some!(&option, value <  &6);
+/// assert_some!(&option, value <= &6);
+/// assert_some!(&option, value >  &4);
+/// assert_some!(&option, value >= &4);
+/// ```
+/// 
+/// ### Example Error Messages
+/// 
+/// ```text
+/// thread 'main' panicked at 'assertion failed: (&option is Some(_))
+///  &option: None
+/// ', src/enums.rs:699:9
+/// ```
+/// ```text
+/// thread 'main' panicked at 'assertion failed: (Some(left) => { left > right })
+///   left: 5
+///  right: 5
+/// ', src/enums.rs:679:9
+/// ```
 #[macro_export]
 macro_rules! assert_some {
     ($option:expr) => {{
         if let None = $option {
             panic!(
-                "assertion failed: ({0} == Some(_))\n {0}: {1:?}\n",
+                "assertion failed: ({0} is Some(_))\n {0}: {1:?}\n",
                 stringify!($option),
                 $option,
             );
         }
-        $crate::enums::ChainSome::new($option)
+    }};
+    ($option:expr, value == $value:expr) => {{
+        assert_some!($option);
+        if let Some(val) = $option {
+            if val != $value {
+                panic!(
+                    "assertion failed: (Some(left) => {{ left == right }})\n  left: {:?}\n right: {:?}\n",
+                    val,
+                    $value,
+                )
+            }
+        }
+    }};
+    ($option:expr, value != $value:expr) => {{
+        assert_some!($option);
+        if let Some(val) = $option {
+            if val == $value {
+                panic!(
+                    "assertion failed: (Some(left) => {{ left != right }})\n  left: {:?}\n right: {:?}\n",
+                    val,
+                    $value,
+                )
+            }
+        }
+    }};
+    ($option:expr, value < $value:expr) => {{
+        assert_some!($option);
+        if let Some(val) = $option {
+            if val >= $value {
+                panic!(
+                    "assertion failed: (Some(left) => {{ left < right }})\n  left: {:?}\n right: {:?}\n",
+                    val,
+                    $value,
+                )
+            }
+        }
+    }};
+    ($option:expr, value <= $value:expr) => {{
+        assert_some!($option);
+        if let Some(val) = $option {
+            if val > $value {
+                panic!(
+                    "assertion failed: (Some(left) => {{ left <= right }})\n  left: {:?}\n right: {:?}\n",
+                    val,
+                    $value,
+                )
+            }
+        }
+    }};
+    ($option:expr, value > $value:expr) => {{
+        assert_some!($option);
+        if let Some(val) = $option {
+            if val <= $value {
+                panic!(
+                    "assertion failed: (Some(left) => {{ left > right }})\n  left: {:?}\n right: {:?}\n",
+                    val,
+                    $value,
+                )
+            }
+        }
+    }};
+    ($option:expr, value >= $value:expr) => {{
+        assert_some!($option);
+        if let Some(val) = $option {
+            if val < $value {
+                panic!(
+                    "assertion failed: (Some(left) => {{ left >= right }})\n  left: {:?}\n right: {:?}\n",
+                    val,
+                    $value,
+                )
+            }
+        }
     }};
 }
 
+/// Asserts that an [Option](https://doc.rust-lang.org/std/option/enum.Option.html) is `None`
+/// 
+/// ### Parameters
+/// 
+/// - `&option` A reference to an `Option`.
+/// 
+/// ### Examples
+/// 
+/// ```rust
+/// use totems::assert_none;
+/// let option = "z".parse::<u32>().ok();
+/// assert_none!(&option);
+/// ```
+/// 
+/// ### Example Error Messages
+/// 
+/// ```text
+/// thread 'enums::none::is_some' panicked at 'assertion failed: (&option is None)
+///  &option: Some(5)
+/// ', src/enums.rs:743:9
+/// ```
 #[macro_export]
 macro_rules! assert_none {
     ($option:expr) => {{
         if let Some(_) = $option {
             panic!(
-                "assertion failed: ({0} == None\n {0}: {1:?}\n",
+                "assertion failed: ({0} is None)\n {0}: {1:?}\n",
                 stringify!($option),
                 $option,
             );
         }
     }};
 }
-
 
 //=============================================================================================
 // Unit Tests
@@ -123,26 +436,90 @@ mod ok {
     }
 
     #[test]
-    fn correct_value() {
+    fn eq_correct() {
         let result = "5".parse::<u32>();
-        assert_ok!(&result).with_value(&5);
+        assert_ok!(&result, value == &5);
     }
 
     #[test]
     #[should_panic]
-    fn incorrect_value() {
+    fn eq_incorrect() {
         let result = "5".parse::<u32>();
-        assert_ok!(&result).with_value(&2);
+        assert_ok!(&result, value == &2);
+    }
+
+    #[test]
+    fn ne_correct() {
+        let result = "5".parse::<u32>();
+        assert_ok!(&result, value != &2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn ne_incorrect() {
+        let result = "5".parse::<u32>();
+        assert_ok!(&result, value != &5);
+    }
+
+    #[test]
+    fn lt_correct() {
+        let result = "5".parse::<u32>();
+        assert_ok!(&result, value < &6);
+    }
+
+    #[test]
+    #[should_panic]
+    fn lt_incorrect() {
+        let result = "5".parse::<u32>();
+        assert_ok!(&result, value < &5);
+    }
+
+    #[test]
+    fn le_correct() {
+        let result = "5".parse::<u32>();
+        assert_ok!(&result, value <= &5);
+    }
+
+    #[test]
+    #[should_panic]
+    fn le_incorrect() {
+        let result = "5".parse::<u32>();
+        assert_ok!(&result, value <= &4);
+    }
+
+    #[test]
+    fn gt_correct() {
+        let result = "5".parse::<u32>();
+        assert_ok!(&result, value > &4);
+    }
+
+    #[test]
+    #[should_panic]
+    fn gt_incorrect() {
+        let result = "5".parse::<u32>();
+        assert_ok!(&result, value > &5);
+    }
+
+    #[test]
+    fn ge_correct() {
+        let result = "5".parse::<u32>();
+        assert_ok!(&result, value >= &5);
+    }
+
+    #[test]
+    #[should_panic]
+    fn ge_incorrect() {
+        let result = "5".parse::<u32>();
+        assert_ok!(&result, value >= &6);
     }
 
     #[test]
     #[should_panic]
     fn is_err() {
         let result = "z".parse::<u32>();
-        assert_ok!(&result).with_value(&5);
+        assert_ok!(&result, value == &5);
     }
 }
-
 
 #[cfg(test)]
 mod err {
@@ -153,14 +530,103 @@ mod err {
     }
 
     #[test]
+    fn eq_correct() {
+        let result: Result<(), &str> = Err("This message matches.");
+        let err = "This message matches.";
+        assert_err!(&result, value == &err);
+    }
+
+    #[test]
     #[should_panic]
-    fn is_some() {
+    fn eq_incorrect() {
+        let result: Result<(), &str> = Err("This message matches.");
+        let err = "This message doesn't match.";
+        assert_err!(&result, value == &err);
+    }
+
+    #[test]
+    fn ne_correct() {
+        let result: Result<(), &str> = Err("This message matches.");
+        let err = "This message does not match.";
+        assert_err!(&result, value != &err);
+    }
+
+    #[test]
+    #[should_panic]
+    fn ne_incorrect() {
+        let result: Result<(), &str> = Err("This message matches.");
+        let err = "This message matches.";
+        assert_err!(&result, value != &err);
+    }
+
+    #[test]
+    fn lt_correct() {
+        let result: Result<(), u32> = Err(5);
+        let err = 6;
+        assert_err!(&result, value < &err);
+    }
+
+    #[test]
+    #[should_panic]
+    fn lt_incorrect() {
+        let result: Result<(), u32> = Err(5);
+        let err = 5;
+        assert_err!(&result, value < &err);
+    }
+
+    #[test]
+    fn le_correct() {
+        let result: Result<(), u32> = Err(5);
+        let err = 5;
+        assert_err!(&result, value <= &err);
+    }
+
+    #[test]
+    #[should_panic]
+    fn le_incorrect() {
+        let result: Result<(), u32> = Err(5);
+        let err = 4;
+        assert_err!(&result, value <= &err);
+    }
+
+
+    #[test]
+    fn gt_correct() {
+        let result: Result<(), u32> = Err(5);
+        let err = 4;
+        assert_err!(&result, value > &err);
+    }
+
+    #[test]
+    #[should_panic]
+    fn gt_incorrect() {
+        let result: Result<(), u32> = Err(5);
+        let err = 5;
+        assert_err!(&result, value > &err);
+    }
+
+    #[test]
+    fn ge_correct() {
+        let result: Result<(), u32> = Err(5);
+        let err = 5;
+        assert_err!(&result, value >= &err);
+    }
+
+    #[test]
+    #[should_panic]
+    fn ge_incorrect() {
+        let result: Result<(), u32> = Err(5);
+        let err = 6;
+        assert_err!(&result, value >= &err);
+    }
+
+    #[test]
+    #[should_panic]
+    fn is_err() {
         let result = "5".parse::<u32>();
         assert_err!(result);
     }
 }
-
-
 
 #[cfg(test)]
 mod some {
@@ -171,23 +637,88 @@ mod some {
     }
 
     #[test]
-    fn correct_value() {
+    fn eq_correct() {
         let option = "5".parse::<u32>().ok();
-        assert_some!(&option).with_value(&5);
+        assert_some!(&option, value == &5);
     }
 
     #[test]
     #[should_panic]
-    fn incorrect_value() {
+    fn eq_incorrect() {
         let option = "5".parse::<u32>().ok();
-        assert_some!(&option).with_value(&2);
+        assert_some!(&option, value == &2);
+    }
+
+    #[test]
+    fn ne_correct() {
+        let option = "5".parse::<u32>().ok();
+        assert_some!(&option, value != &2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn ne_incorrect() {
+        let option = "5".parse::<u32>().ok();
+        assert_some!(&option, value != &5);
+    }
+
+    #[test]
+    fn lt_correct() {
+        let option = "5".parse::<u32>().ok();
+        assert_some!(&option, value < &6);
+    }
+
+    #[test]
+    #[should_panic]
+    fn lt_incorrect() {
+        let option = "5".parse::<u32>().ok();
+        assert_some!(&option, value < &5);
+    }
+
+    #[test]
+    fn le_correct() {
+        let option = "5".parse::<u32>().ok();
+        assert_some!(&option, value <= &5);
+    }
+
+    #[test]
+    #[should_panic]
+    fn le_incorrect() {
+        let option = "5".parse::<u32>().ok();
+        assert_some!(&option, value <= &4);
+    }
+
+    #[test]
+    fn gt_correct() {
+        let option = "5".parse::<u32>().ok();
+        assert_some!(&option, value > &4);
+    }
+
+    #[test]
+    #[should_panic]
+    fn gt_incorrect() {
+        let option = "5".parse::<u32>().ok();
+        assert_some!(&option, value > &5);
+    }
+
+    #[test]
+    fn ge_correct() {
+        let option = "5".parse::<u32>().ok();
+        assert_some!(&option, value >= &5);
+    }
+
+    #[test]
+    #[should_panic]
+    fn ge_incorrect() {
+        let option = "5".parse::<u32>().ok();
+        assert_some!(&option, value >= &6);
     }
 
     #[test]
     #[should_panic]
     fn is_none() {
         let option = "z".parse::<u32>().ok();
-        assert_some!(&option).with_value(&5);
+        assert_some!(&option, value == &5);
     }
 }
 
@@ -206,4 +737,3 @@ mod none {
         assert_none!(&option);
     }
 }
-

--- a/src/inequalities.rs
+++ b/src/inequalities.rs
@@ -2,6 +2,32 @@
 // Macros
 //=============================================================================================
 
+/// Asserts `(left <  right)`.
+/// 
+/// ### Parameters
+/// 
+/// - `left` The left operand of the comparison.
+/// - `right` The right operand of the comparison.
+/// 
+/// ### Dependencies
+/// - `left` and `right` must be at least [PartialOrd](https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html)
+/// 
+/// ### Example
+///
+/// ```
+/// use totems::assert_lt;
+/// let x = 4;
+/// let y = 5;
+/// assert_lt!(x, y)
+/// ```
+/// 
+/// ### Example Error Messages
+/// 
+/// ```text
+/// thread 'inequalities::lt::incorrect' panicked at 'assertion failed: `(left < right)`
+///   left: `5`,
+///  right: `5`', src/inequalities.rs:245:9
+/// ```
 #[macro_export]
 macro_rules! assert_lt {
     ($left:expr, $right:expr) => ({
@@ -38,6 +64,32 @@ macro_rules! assert_lt {
     });
 }
 
+/// Asserts `(left <= right)`.
+/// 
+/// ### Parameters
+/// 
+/// - `left` The left operand of the comparison.
+/// - `right` The right operand of the comparison.
+/// 
+/// ### Dependencies
+/// - `left` and `right` must be at least [PartialOrd](https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html)
+/// 
+/// ### Example
+///
+/// ```
+/// use totems::assert_le;
+/// let x = 4;
+/// let y = 5;
+/// assert_le!(x, y)
+/// ```
+/// 
+/// ### Example Error Messages
+/// 
+/// ```text
+/// thread 'inequalities::le::incorrect' panicked at 'assertion failed: `(left <= right)`
+///   left: `6`,
+///  right: `5`', src/inequalities.rs:270:9
+/// ```
 #[macro_export]
 macro_rules! assert_le {
     ($left:expr, $right:expr) => ({
@@ -74,6 +126,32 @@ macro_rules! assert_le {
     });
 }
 
+/// Asserts `(left >  right)`.
+/// 
+/// ### Parameters
+/// 
+/// - `left` The left operand of the comparison.
+/// - `right` The right operand of the comparison.
+/// 
+/// ### Dependencies
+/// - `left` and `right` must be at least [PartialOrd](https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html)
+/// 
+/// ### Example
+///
+/// ```
+/// use totems::assert_gt;
+/// let x = 5;
+/// let y = 4;
+/// assert_gt!(x, y)
+/// ```
+/// 
+/// ### Example Error Messages
+/// 
+/// ```text
+/// thread 'inequalities::gt::incorrect' panicked at 'assertion failed: `(left > right)`
+///   left: `5`,
+///  right: `5`', src/inequalities.rs:295:9
+/// ```
 #[macro_export]
 macro_rules! assert_gt {
     ($left:expr, $right:expr) => ({
@@ -110,6 +188,32 @@ macro_rules! assert_gt {
     });
 }
 
+/// Asserts `(left >= right)`.
+/// 
+/// ### Parameters
+/// 
+/// - `left` The left operand of the comparison.
+/// - `right` The right operand of the comparison.
+/// 
+/// ### Dependencies
+/// - `left` and `right` must be at least [PartialOrd](https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html)
+/// 
+/// ### Example
+///
+/// ```
+/// use totems::assert_ge;
+/// let x = 5;
+/// let y = 4;
+/// assert_ge!(x, y)
+/// ```
+/// 
+/// ### Example Error Messages
+/// 
+/// ```text
+/// thread 'inequalities::ge::incorrect' panicked at 'assertion failed: `(left >= right)`
+///   left: `5`,
+///  right: `6`', src/inequalities.rs:320:9
+/// ```
 #[macro_export]
 macro_rules! assert_ge {
     ($left:expr, $right:expr) => ({


### PR DESCRIPTION
- Macros no longer use a chain struct. This was breaking the line
numbers.
- Macros that previously used a chain struct now just have options to
compare inequalities.
- Added documentation for all macros so far.